### PR TITLE
fix: express deprecated req.host

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -102,7 +102,7 @@ function getRequestStructure(req, includeBody, includeHeaders) {
         query: req.query,
         path: req.path,
         scheme: req.protocol,
-        host: req.host,
+        host: req.hostname,
     };
 
     if (includeBody) {


### PR DESCRIPTION
## What

Updated /lib/index.js:105 from req.host to req.hostname

## Why

express deprecated req.host: Use req.hostname instead node_modules/@build-security/opa-express-middleware/lib/index.js:105:19

![image](https://user-images.githubusercontent.com/60555857/106652216-f5747480-6549-11eb-8c49-8d374a8f329b.png)


